### PR TITLE
Add APRIL paper to post-training section and fix broken ToC link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A curated list of Large Language Model systems related academic papers, articles
 - [Industrial LLM Technical Report](#industrial-llm-technical-report)
 - [LLM Frameworks](#llm-frameworks)
   - [Training](#training-1)
+  - [Post-Training](#post-training)
   - [Serving](#serving-1)
 - [ML Systems](#ml-systems)
 - [Survey Paper](#survey-paper)


### PR DESCRIPTION
Addresses issue #14

## Changes:
- Added APRIL paper to Systems for Post-training/RLHF section
- Fixed broken Table of Contents link for Post-Training section

Generated with [Claude Code](https://claude.ai/code)