### PR TITLE
Add papers and blog post to LLM serving section

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ A curated list of Large Language Model systems related academic papers, articles
 - [Taming the Chaos](https://arxiv.org/abs/2508.19559): Coordinated Autoscaling for Heterogeneous and Disaggregated LLM Inference | Seed
 - [TokenLake](https://arxiv.org/abs/2508.17219): A Unified Segment-level Prefix Cache Pool for Fine-grained Elastic Long-Context LLM Serving
 - [Expert-as-a-Service](https://arxiv.org/abs/2509.17863): Towards Efficient, Scalable, and Robust Large-scale MoE Serving
+- [Defeating Nondeterminism in LLM Inference](https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/) | Blog
+- [Paper on LLM Systems](https://arxiv.org/abs/2509.19836)
+- [Paper on LLM Systems](https://arxiv.org/abs/2509.21841)
+- [Paper on LLM Systems](https://arxiv.org/pdf/2509.16495)
 
 #### Agent Systems
 - [Supporting Our AI Overlords](https://arxiv.org/pdf/2509.00997): Redesigning Data Systems to be Agent-First | UCB


### PR DESCRIPTION
Adds resources requested in issue #18:
- 'Defeating Nondeterminism in LLM Inference' blog post
- arXiv papers 2509.19836, 2509.21841, 2509.16495

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds one blog post and three new arXiv papers to the LLM Serving section of README.
> 
> - **README – Serving**:
>   - Add `Defeating Nondeterminism in LLM Inference` (blog).
>   - Add three new arXiv resources: `2509.19836`, `2509.21841`, and `2509.16495`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fc96f5b2f8ab785210e02a46fc958e416f96eb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->