### PR TITLE
Add two new papers to LLMSys-PaperList

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A curated list of Large Language Model systems related academic papers, articles
 - [Mycroft: Tracing Dependencies in Collective Communication Towards Reliable LLM Training](https://sigops.org/s/conferences/sosp/2025/accepted.html) | SOSP' 25
 - [DCP: Addressing Input Dynamism In Long-Context Training via Dynamic Context Parallelism](https://sigops.org/s/conferences/sosp/2025/accepted.html) | SOSP' 25
 - [TrainVerify: Equivalence-Based Verification for Distributed LLM Training](https://sigops.org/s/conferences/sosp/2025/accepted.html) | SOSP' 25
+- [Collective Communication for 100k+ GPUs](https://arxiv.org/abs/2510.20171): Large-scale collective communication optimization for massive GPU clusters
 
 
 #### Systems for Post-training / RLHF 
@@ -222,6 +223,7 @@ A curated list of Large Language Model systems related academic papers, articles
 - [PrefillOnly: An Inference Engine for Prefill-only Workloads in Large Language Model Applications](https://sigops.org/s/conferences/sosp/2025/accepted.html) | SOSP' 25
 - [KTransformers: Unleashing the Full Potential of CPU/GPU Hybrid Inference for MoE Models](https://sigops.org/s/conferences/sosp/2025/accepted.html) | SOSP' 25
 - [The ML.ENERGY Benchmark](https://arxiv.org/abs/2505.06371): Toward Automated Inference Energy Measurement and Optimization | NeurIPS' 25
+- [Serve Programs, Not Prompts](https://arxiv.org/abs/2510.25412): Efficient LLM serving system for structured program execution
 
 
 #### Agent Systems


### PR DESCRIPTION
## Summary

This PR adds two new papers as requested in issue #27:

1. **Serve Programs, Not Prompts** (arXiv:2510.25412) - Added to LLM serving section
2. **Collective Communication for 100k+ GPUs** (arXiv:2510.20171) - Added to Pre-training section

Both papers follow the repository's formatting guidelines with proper arXiv links and descriptions.

Closes #27

---

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds two papers to README: “Collective Communication for 100k+ GPUs” under Pre-training and “Serve Programs, Not Prompts” under LLM serving.
> 
> - **README updates** (`README.md`):
>   - **Training › Pre-training**:
>     - Add “Collective Communication for 100k+ GPUs” with arXiv link and brief description.
>   - **Serving › LLM serving**:
>     - Add “Serve Programs, Not Prompts” with arXiv link and brief description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 304b1696a489ec9a49d3558d173aec1bdfa1c34d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->