### PR TITLE
Add Hugging Face training playbooks to Related ML Readings

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,8 @@ A curated list of Large Language Model systems related academic papers, articles
 - [Transformer Inference Arithmetic](https://kipp.ly/transformer-inference-arithmetic/)
 - [The Transformer Family Version 2.0](https://lilianweng.github.io/posts/2023-01-27-the-transformer-family-v2/)
 - [Full Stack Optimization of Transformer Inference](https://arxiv.org/pdf/2302.14017.pdf): a Survey | UCB
+- [The Smol Training Playbook](https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook): The Secrets to Building World-Class LLMs | Hugging Face
+- [The Ultra-Scale Playbook](https://huggingface.co/spaces/nanotron/ultrascale-playbook): Training LLMs on GPU Clusters | Hugging Face
 
 ## MLSys Courses
 - Systems for Machine Learning | (Stanford)[https://cs229s.stanford.edu/fall2023/]


### PR DESCRIPTION
Added two comprehensive training guides from Hugging Face:
- The Smol Training Playbook: Secrets to Building World-Class LLMs
- The Ultra-Scale Playbook: Training LLMs on GPU Clusters

Resolves #29

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add two Hugging Face training playbook links to the README’s Related ML Readings section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d1b44e48e04274253ef4fd01d7cee2980496a0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->