### PR TITLE
fix: remove duplicate paper entry for arXiv 2407.00047

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ A curated list of Large Language Model systems related academic papers, articles
 - [NanoFlow](https://arxiv.org/abs/2408.12757): Towards Optimal Large Language Model Serving Throughput
 - [Responsive ML inference in multi-tenanted environments using AQUA](https://arxiv.org/abs/2407.21255)
 - [One Queue Is All You Need](https://arxiv.org/abs/2407.00047): Resolving Head-of-Line Blocking in Large Language Model Serving
-- [Queue management for slo-oriented large language model serving](https://arxiv.org/abs/2407.00047v2): Queue management strategies for meeting SLO requirements in LLM serving
 - [MemServe](https://arxiv.org/abs/2406.17565): Context Caching for Disaggregated LLM Serving with Elastic Memory Pool
 - [dLoRA: Dynamically Orchestrating Requests and Adapters for LoRA LLM Serving](https://www.usenix.org/conference/osdi24/presentation/wu-bingyang) | OSDI' 24
 - [Llumnix](https://www.usenix.org/conference/osdi24/presentation/sun-biao): Dynamic Scheduling for Large Language Model Serving | OSDI' 24


### PR DESCRIPTION
This PR fixes the duplicate paper issue identified in PR #33.

### Summary
Removes duplicate entry 'Queue management for slo-oriented large language model serving' which is the same paper as 'One Queue Is All You Need' (both reference arXiv:2407.00047).

### Changes
- Removed line 167 from README.md (duplicate paper entry)
- Kept line 166 with the proper title 'One Queue Is All You Need'

Resolves the duplicate issue from PR #33

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the duplicate listing of arXiv:2407.00047, keeping the correct "One Queue Is All You Need" entry.
> 
> - **Docs**: In `README.md` under `Serving` > `LLM serving`, remove duplicate paper entry `Queue management for slo-oriented large language model serving` (arXiv:2407.00047); retain `One Queue Is All You Need`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aae396b192a43dcf65e7779a8c602c6f481be69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->