### PR TITLE
Add AI Research Engineering Skills Library 

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ A curated list of Large Language Model systems related academic papers, articles
 - [GMorph](https://dl.acm.org/doi/10.1145/3627703.3650074): Accelerating Multi-DNN Inference via Model Fusion | EuroSys '24
 - [Automatic Root Cause Analysis via Large Language Models for Cloud Incidents](https://dl.acm.org/doi/10.1145/3627703.3629553) | EuroSys '24
 - [KNighter: Transforming Static Analysis with LLM-Synthesized Checkers](https://sigops.org/s/conferences/sosp/2025/accepted.html) | SOSP' 25
+- [Barbarians at the Gate: How AI is Upending Systems Research](https://arxiv.org/abs/2510.06189)
+- [AI Research Engineering Skills Library](https://github.com/zechenzhangAGI/claude-ai-research-skills): A collection of AI research engineering skills and best practices
 
 ## Industrial LLM Technical Report   
  


### PR DESCRIPTION
Adds two new entries to the 'LLM for Systems' section:

1. AI Research Engineering Skills Library - A GitHub repository with AI research engineering skills and best practices
2. Barbarians at the Gate: How AI is Upending Systems Research - arXiv paper

Resolves #35

---
Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds two entries to `LLM for Systems`: the Barbarians-at-the-Gate paper and an AI Research Engineering Skills Library repo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9ace50ce8f0142aa5afddc33b784fd9b264509f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->