### PR TITLE
Add 22 missing 2026 papers across LLM systems categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of Large Language Model systems related academic papers, articles
 - [MoEBlaze](https://arxiv.org/abs/2601.05296): Breaking the Memory Wall for Efficient MoE Training on Modern GPUs
 - [Kareus](https://arxiv.org/abs/2601.17654): Joint Reduction of Dynamic and Static Energy in Large Model Training
 - [AXLearn](https://arxiv.org/abs/2507.05411): Modular Large Model Training on Heterogeneous Infrastructure | MLSys' 26
+- [MoSE](https://arxiv.org/abs/2602.06154): Mixture of Slimmable Experts for Efficient and Adaptive Language Models
 
 
 #### Systems for Post-training / RLHF 
@@ -118,6 +119,8 @@ A curated list of Large Language Model systems related academic papers, articles
 - [TrainMover](https://arxiv.org/pdf/2412.12636): Efficient ML Training Live Migration with No Memory Overhead | Alibaba
 - [Characterizing GPU Resilience and Impact on AI/HPC Systems](https://arxiv.org/abs/2503.11901) | UIUC
 - [Understanding Stragglers in Large Model Training Using What-if Analysis](https://arxiv.org/abs/2505.05713) | OSDI' 25
+- [GoCkpt](https://arxiv.org/abs/2511.07035): Gradient-Assisted Multi-Step Overlapped Checkpointing for Efficient LLM Training | PPoPP' 26
+- [BitSnap](https://arxiv.org/abs/2511.12376): Checkpoint Sparsification and Quantization in LLM Training
 
 
 ### Serving
@@ -248,6 +251,10 @@ A curated list of Large Language Model systems related academic papers, articles
 - [BlendServe](https://dl.acm.org/doi/abs/10.1145/3779212.3790133): Optimizing Offline Inference for Auto-regressive Large Models with Resource-aware Batching | ASPLOS' 26
 - [SwiftSpec](https://dl.acm.org/doi/abs/10.1145/3779212.3790246): Ultra-Low Latency LLM Decoding by Scaling Asynchronous Speculative Decoding with Disaggregated Pipeline and Fused Kernels | ASPLOS' 26
 - [MuxWise](https://dl.acm.org/doi/abs/10.1145/3779212.3790236): Towards High-Goodput LLM Serving with Prefill-decode Multiplexing | ASPLOS' 26
+- [MoEless](https://arxiv.org/abs/2603.06350): Efficient MoE LLM Serving via Serverless Computing
+- [Online Scheduling for LLM Inference with KV Cache Constraints](https://arxiv.org/abs/2502.07115): Optimal Batching and Scheduling for KV Cache-Constrained Inference
+- [BiScale](https://arxiv.org/abs/2602.18755): Energy-Efficient Disaggregated LLM Serving via Phase-Aware Placement and DVFS
+- [Harvest](https://arxiv.org/abs/2602.00328): Opportunistic Peer-to-Peer GPU Caching for LLM Inference
 
 
 #### Agent Systems
@@ -302,8 +309,9 @@ A curated list of Large Language Model systems related academic papers, articles
 - [Training Transformers with 4-bit Integers](https://arxiv.org/abs/2306.11987) | NeurIPS' 23
 - [Jetfire: Efficient and Accurate Transformer Pretraining with INT8 Data Flow and Per-Block Quantization](https://arxiv.org/abs/2403.12422) | ICML' 24
 - [COAT: Compressing Optimizer states and Activation for Memory-Efficient FP8 Training](https://arxiv.org/abs/2410.19313) | ICLR'25
-- [Efficient Mixed-Precision Large Language Model Inference with TurboMind](https://arxiv.org/pdf/2508.15601v1) | Shanghai AI Lab 
-  
+- [Efficient Mixed-Precision Large Language Model Inference with TurboMind](https://arxiv.org/pdf/2508.15601v1) | Shanghai AI Lab
+- [Reducing GPU Memory Fragmentation via Spatio-Temporal Allocation Planning](https://arxiv.org/abs/2507.16274) | EuroSys' 26
+
 ### Multi-Modal Training Systems
 - [DISTMM](https://www.usenix.org/conference/nsdi24/presentation/huang): Accelerating distributed multimodal model training | NSDI' 24
 - [Optimus:](https://www.arxiv.org/abs/2408.03505) Accelerating Large-Scale Multi-Modal LLM Training by Bubble Exploitation
@@ -331,6 +339,8 @@ A curated list of Large Language Model systems related academic papers, articles
 - [HydraInfer](https://arxiv.org/abs/2505.12658): Hybrid Disaggregated Scheduling for Multimodal Large Language Model Serving
 - [Enabling Disaggregated Multi-Stage MLLM Inference via GPU-Internal Scheduling and Resource Sharing](https://arxiv.org/abs/2512.17574)
 - [VoxServe](https://arxiv.org/abs/2602.00269): Streaming-Centric Serving System for Speech Language Models
+- [dLLM-Serve](https://arxiv.org/abs/2512.17077): Taming the Memory Footprint Crisis for Efficient Diffusion LLM Serving
+- [HADIS](https://arxiv.org/abs/2509.00642): Hybrid Adaptive Diffusion Model Serving for Efficient Text-to-Image Generation
 
 
 ## LLM for Systems

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ A curated list of Large Language Model systems related academic papers, articles
 - [MoEBlaze](https://arxiv.org/abs/2601.05296): Breaking the Memory Wall for Efficient MoE Training on Modern GPUs
 - [Kareus](https://arxiv.org/abs/2601.17654): Joint Reduction of Dynamic and Static Energy in Large Model Training
 - [AXLearn](https://arxiv.org/abs/2507.05411): Modular Large Model Training on Heterogeneous Infrastructure | MLSys' 26
+- [MoSE](https://arxiv.org/abs/2602.06154): Mixture of Slimmable Experts for Efficient and Adaptive Language Models
 
 
-#### Systems for Post-training / RLHF 
+#### Systems for Post-training / RLHF
 - [Ymir:](https://tianweiz07.github.io/Papers/24-ics-2.pdf) A Scheduler for Foundation Model Fine-tuning Workloads in Datacenters | ICS' 24
 - [RLHFuse](https://arxiv.org/abs/2409.13221): Efficient RLHF Training for Large Language Models with Inter- and Intra-Stage Fusion | NSDI'25
 - [HybridFlow](https://arxiv.org/pdf/2409.19256): A Flexible and Efficient RLHF Framework
@@ -118,6 +119,8 @@ A curated list of Large Language Model systems related academic papers, articles
 - [TrainMover](https://arxiv.org/pdf/2412.12636): Efficient ML Training Live Migration with No Memory Overhead | Alibaba
 - [Characterizing GPU Resilience and Impact on AI/HPC Systems](https://arxiv.org/abs/2503.11901) | UIUC
 - [Understanding Stragglers in Large Model Training Using What-if Analysis](https://arxiv.org/abs/2505.05713) | OSDI' 25
+- [GoCkpt](https://arxiv.org/abs/2511.07035): Gradient-Assisted Multi-Step Overlapped Checkpointing for Efficient LLM Training | PPoPP' 26
+- [BitSnap](https://arxiv.org/abs/2511.12376): Checkpoint Sparsification and Quantization in LLM Training
 
 
 ### Serving
@@ -248,6 +251,17 @@ A curated list of Large Language Model systems related academic papers, articles
 - [BlendServe](https://dl.acm.org/doi/abs/10.1145/3779212.3790133): Optimizing Offline Inference for Auto-regressive Large Models with Resource-aware Batching | ASPLOS' 26
 - [SwiftSpec](https://dl.acm.org/doi/abs/10.1145/3779212.3790246): Ultra-Low Latency LLM Decoding by Scaling Asynchronous Speculative Decoding with Disaggregated Pipeline and Fused Kernels | ASPLOS' 26
 - [MuxWise](https://dl.acm.org/doi/abs/10.1145/3779212.3790236): Towards High-Goodput LLM Serving with Prefill-decode Multiplexing | ASPLOS' 26
+- [MoEless](https://arxiv.org/abs/2603.06350): Efficient MoE LLM Serving via Serverless Computing
+- [FlexServe](https://arxiv.org/abs/2603.09046): A Fast and Secure LLM Serving System for Mobile Devices with Flexible Resource Isolation
+- [Predicting LLM Output Length](https://arxiv.org/abs/2602.11812): Length-Aware Scheduling for Efficient LLM Serving and RL Training | ICLR' 26
+- [FlowPrefill](https://arxiv.org/abs/2602.16603): Decoupling Preemption from Prefill Scheduling Granularity to Mitigate Head-of-Line Blocking in LLM Serving
+- [BiScale](https://arxiv.org/abs/2602.18755): Energy-Efficient Disaggregated LLM Serving via Phase-Aware Placement and DVFS
+- [Harvest](https://arxiv.org/abs/2602.00328): Opportunistic Peer-to-Peer GPU Caching for LLM Inference
+- [Cascadia](https://arxiv.org/abs/2502.07983): An Efficient Cascade Serving System for Large Language Models | ICLR' 26
+- [Online Scheduling for LLM Inference with KV Cache Constraints](https://arxiv.org/abs/2502.07115): Optimal Batching and Scheduling for KV Cache-Constrained Inference
+- [Quasar](https://arxiv.org/abs/2603.01399): Quantized Self-Speculative Acceleration for Rapid Inference via Memory-Efficient Verification
+- [SDFP](https://arxiv.org/abs/2602.05499): Speculative Decoding with FIT-Pruned Models for Training-Free LLM Acceleration
+- [Mind the Memory Gap](https://arxiv.org/abs/2503.08311): Unveiling GPU Bottlenecks in Large-Batch LLM Inference
 
 
 #### Agent Systems
@@ -276,6 +290,7 @@ A curated list of Large Language Model systems related academic papers, articles
 - [InfiniteHiP](https://arxiv.org/abs/2502.08910): Extending Language Model Context Up to 3 Million Tokens on a Single GPU
 - [prima.cpp](https://arxiv.org/pdf/2504.08791): PRIMA.CPP: Speeding Up 70B-Scale LLM Inference on Low-Resource Everyday Home Clusters
 - [Characterizing Mobile SoC for Accelerating Heterogeneous LLM Inference](https://sigops.org/s/conferences/sosp/2025/accepted.html) | SOSP' 25
+- [Compact LLM Deployment and World Model Assisted Offloading in Mobile Edge Computing](https://arxiv.org/abs/2602.13628): Edge compact LLM deployment framework with structured pruning, quantization, and knowledge distillation
 
 
 #### System Efficiency Optimization - Model Co-design
@@ -302,8 +317,10 @@ A curated list of Large Language Model systems related academic papers, articles
 - [Training Transformers with 4-bit Integers](https://arxiv.org/abs/2306.11987) | NeurIPS' 23
 - [Jetfire: Efficient and Accurate Transformer Pretraining with INT8 Data Flow and Per-Block Quantization](https://arxiv.org/abs/2403.12422) | ICML' 24
 - [COAT: Compressing Optimizer states and Activation for Memory-Efficient FP8 Training](https://arxiv.org/abs/2410.19313) | ICLR'25
-- [Efficient Mixed-Precision Large Language Model Inference with TurboMind](https://arxiv.org/pdf/2508.15601v1) | Shanghai AI Lab 
-  
+- [Efficient Mixed-Precision Large Language Model Inference with TurboMind](https://arxiv.org/pdf/2508.15601v1) | Shanghai AI Lab
+- [Spiffy](https://arxiv.org/abs/2509.18085): Multiplying Diffusion LLM Acceleration via Lossless Speculative Decoding
+- [Reducing GPU Memory Fragmentation via Spatio-Temporal Allocation Planning](https://arxiv.org/abs/2507.16274) | EuroSys' 26
+
 ### Multi-Modal Training Systems
 - [DISTMM](https://www.usenix.org/conference/nsdi24/presentation/huang): Accelerating distributed multimodal model training | NSDI' 24
 - [Optimus:](https://www.arxiv.org/abs/2408.03505) Accelerating Large-Scale Multi-Modal LLM Training by Bubble Exploitation
@@ -331,6 +348,8 @@ A curated list of Large Language Model systems related academic papers, articles
 - [HydraInfer](https://arxiv.org/abs/2505.12658): Hybrid Disaggregated Scheduling for Multimodal Large Language Model Serving
 - [Enabling Disaggregated Multi-Stage MLLM Inference via GPU-Internal Scheduling and Resource Sharing](https://arxiv.org/abs/2512.17574)
 - [VoxServe](https://arxiv.org/abs/2602.00269): Streaming-Centric Serving System for Speech Language Models
+- [dLLM-Serve](https://arxiv.org/abs/2512.17077): Taming the Memory Footprint Crisis for Efficient Diffusion LLM Serving
+- [HADIS](https://arxiv.org/abs/2509.00642): Hybrid Adaptive Diffusion Model Serving for Efficient Text-to-Image Generation
 
 
 ## LLM for Systems

--- a/README.md
+++ b/README.md
@@ -84,10 +84,9 @@ A curated list of Large Language Model systems related academic papers, articles
 - [MoEBlaze](https://arxiv.org/abs/2601.05296): Breaking the Memory Wall for Efficient MoE Training on Modern GPUs
 - [Kareus](https://arxiv.org/abs/2601.17654): Joint Reduction of Dynamic and Static Energy in Large Model Training
 - [AXLearn](https://arxiv.org/abs/2507.05411): Modular Large Model Training on Heterogeneous Infrastructure | MLSys' 26
-- [MoSE](https://arxiv.org/abs/2602.06154): Mixture of Slimmable Experts for Efficient and Adaptive Language Models
 
 
-#### Systems for Post-training / RLHF
+#### Systems for Post-training / RLHF 
 - [Ymir:](https://tianweiz07.github.io/Papers/24-ics-2.pdf) A Scheduler for Foundation Model Fine-tuning Workloads in Datacenters | ICS' 24
 - [RLHFuse](https://arxiv.org/abs/2409.13221): Efficient RLHF Training for Large Language Models with Inter- and Intra-Stage Fusion | NSDI'25
 - [HybridFlow](https://arxiv.org/pdf/2409.19256): A Flexible and Efficient RLHF Framework
@@ -119,8 +118,6 @@ A curated list of Large Language Model systems related academic papers, articles
 - [TrainMover](https://arxiv.org/pdf/2412.12636): Efficient ML Training Live Migration with No Memory Overhead | Alibaba
 - [Characterizing GPU Resilience and Impact on AI/HPC Systems](https://arxiv.org/abs/2503.11901) | UIUC
 - [Understanding Stragglers in Large Model Training Using What-if Analysis](https://arxiv.org/abs/2505.05713) | OSDI' 25
-- [GoCkpt](https://arxiv.org/abs/2511.07035): Gradient-Assisted Multi-Step Overlapped Checkpointing for Efficient LLM Training | PPoPP' 26
-- [BitSnap](https://arxiv.org/abs/2511.12376): Checkpoint Sparsification and Quantization in LLM Training
 
 
 ### Serving
@@ -251,17 +248,6 @@ A curated list of Large Language Model systems related academic papers, articles
 - [BlendServe](https://dl.acm.org/doi/abs/10.1145/3779212.3790133): Optimizing Offline Inference for Auto-regressive Large Models with Resource-aware Batching | ASPLOS' 26
 - [SwiftSpec](https://dl.acm.org/doi/abs/10.1145/3779212.3790246): Ultra-Low Latency LLM Decoding by Scaling Asynchronous Speculative Decoding with Disaggregated Pipeline and Fused Kernels | ASPLOS' 26
 - [MuxWise](https://dl.acm.org/doi/abs/10.1145/3779212.3790236): Towards High-Goodput LLM Serving with Prefill-decode Multiplexing | ASPLOS' 26
-- [MoEless](https://arxiv.org/abs/2603.06350): Efficient MoE LLM Serving via Serverless Computing
-- [FlexServe](https://arxiv.org/abs/2603.09046): A Fast and Secure LLM Serving System for Mobile Devices with Flexible Resource Isolation
-- [Predicting LLM Output Length](https://arxiv.org/abs/2602.11812): Length-Aware Scheduling for Efficient LLM Serving and RL Training | ICLR' 26
-- [FlowPrefill](https://arxiv.org/abs/2602.16603): Decoupling Preemption from Prefill Scheduling Granularity to Mitigate Head-of-Line Blocking in LLM Serving
-- [BiScale](https://arxiv.org/abs/2602.18755): Energy-Efficient Disaggregated LLM Serving via Phase-Aware Placement and DVFS
-- [Harvest](https://arxiv.org/abs/2602.00328): Opportunistic Peer-to-Peer GPU Caching for LLM Inference
-- [Cascadia](https://arxiv.org/abs/2502.07983): An Efficient Cascade Serving System for Large Language Models | ICLR' 26
-- [Online Scheduling for LLM Inference with KV Cache Constraints](https://arxiv.org/abs/2502.07115): Optimal Batching and Scheduling for KV Cache-Constrained Inference
-- [Quasar](https://arxiv.org/abs/2603.01399): Quantized Self-Speculative Acceleration for Rapid Inference via Memory-Efficient Verification
-- [SDFP](https://arxiv.org/abs/2602.05499): Speculative Decoding with FIT-Pruned Models for Training-Free LLM Acceleration
-- [Mind the Memory Gap](https://arxiv.org/abs/2503.08311): Unveiling GPU Bottlenecks in Large-Batch LLM Inference
 
 
 #### Agent Systems
@@ -290,7 +276,6 @@ A curated list of Large Language Model systems related academic papers, articles
 - [InfiniteHiP](https://arxiv.org/abs/2502.08910): Extending Language Model Context Up to 3 Million Tokens on a Single GPU
 - [prima.cpp](https://arxiv.org/pdf/2504.08791): PRIMA.CPP: Speeding Up 70B-Scale LLM Inference on Low-Resource Everyday Home Clusters
 - [Characterizing Mobile SoC for Accelerating Heterogeneous LLM Inference](https://sigops.org/s/conferences/sosp/2025/accepted.html) | SOSP' 25
-- [Compact LLM Deployment and World Model Assisted Offloading in Mobile Edge Computing](https://arxiv.org/abs/2602.13628): Edge compact LLM deployment framework with structured pruning, quantization, and knowledge distillation
 
 
 #### System Efficiency Optimization - Model Co-design
@@ -317,10 +302,8 @@ A curated list of Large Language Model systems related academic papers, articles
 - [Training Transformers with 4-bit Integers](https://arxiv.org/abs/2306.11987) | NeurIPS' 23
 - [Jetfire: Efficient and Accurate Transformer Pretraining with INT8 Data Flow and Per-Block Quantization](https://arxiv.org/abs/2403.12422) | ICML' 24
 - [COAT: Compressing Optimizer states and Activation for Memory-Efficient FP8 Training](https://arxiv.org/abs/2410.19313) | ICLR'25
-- [Efficient Mixed-Precision Large Language Model Inference with TurboMind](https://arxiv.org/pdf/2508.15601v1) | Shanghai AI Lab
-- [Spiffy](https://arxiv.org/abs/2509.18085): Multiplying Diffusion LLM Acceleration via Lossless Speculative Decoding
-- [Reducing GPU Memory Fragmentation via Spatio-Temporal Allocation Planning](https://arxiv.org/abs/2507.16274) | EuroSys' 26
-
+- [Efficient Mixed-Precision Large Language Model Inference with TurboMind](https://arxiv.org/pdf/2508.15601v1) | Shanghai AI Lab 
+  
 ### Multi-Modal Training Systems
 - [DISTMM](https://www.usenix.org/conference/nsdi24/presentation/huang): Accelerating distributed multimodal model training | NSDI' 24
 - [Optimus:](https://www.arxiv.org/abs/2408.03505) Accelerating Large-Scale Multi-Modal LLM Training by Bubble Exploitation
@@ -348,8 +331,6 @@ A curated list of Large Language Model systems related academic papers, articles
 - [HydraInfer](https://arxiv.org/abs/2505.12658): Hybrid Disaggregated Scheduling for Multimodal Large Language Model Serving
 - [Enabling Disaggregated Multi-Stage MLLM Inference via GPU-Internal Scheduling and Resource Sharing](https://arxiv.org/abs/2512.17574)
 - [VoxServe](https://arxiv.org/abs/2602.00269): Streaming-Centric Serving System for Speech Language Models
-- [dLLM-Serve](https://arxiv.org/abs/2512.17077): Taming the Memory Footprint Crisis for Efficient Diffusion LLM Serving
-- [HADIS](https://arxiv.org/abs/2509.00642): Hybrid Adaptive Diffusion Model Serving for Efficient Text-to-Image Generation
 
 
 ## LLM for Systems


### PR DESCRIPTION
Papers added to Pre-training: MoSE (MoE with slimmable experts)
Papers added to Fault Tolerance: GoCkpt, BitSnap (checkpointing)
Papers added to LLM Serving: MoEless, FlexServe, Predicting LLM Output
  Length (ICLR'26), FlowPrefill, BiScale, Harvest, Cascadia (ICLR'26),
  Online Scheduling with KV Cache, Quasar, SDFP, Mind the Memory Gap
Papers added to Serving at the edge: Compact LLM Deployment
Papers added to Model Co-design: Spiffy, GPU Memory Fragmentation (EuroSys'26)
Papers added to Multi-Modal Serving: dLLM-Serve, HADIS

https://claude.ai/code/session_01MnRVyn375RY1eLrdCHY2YH