### PR TITLE
Add MineDraft: A Framework for Batch Parallel Speculative Decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ A curated list of Large Language Model systems related academic papers, articles
 - [BiScale](https://arxiv.org/abs/2602.18755): Energy-Efficient Disaggregated LLM Serving via Phase-Aware Placement and DVFS
 - [Harvest](https://arxiv.org/abs/2602.00328): Opportunistic Peer-to-Peer GPU Caching for LLM Inference
 - [TokenFlow](files/report.pdf): Responsive LLM Text Streaming Serving under Request Burst via Preemptive Scheduling | Plagiarism
+- [MineDraft](https://arxiv.org/abs/2603.18016): A Framework for Batch Parallel Speculative Decoding — overlaps drafting and verification across two batches, hiding draft latency. Up to +75% throughput, -39% latency. Integrated into vLLM. | NUS & MIT
 
 #### Agent Systems
 - [Supporting Our AI Overlords](https://arxiv.org/pdf/2509.00997): Redesigning Data Systems to be Agent-First | UCB


### PR DESCRIPTION
Hi — thanks for maintaining this awesome list!

I'd like to suggest adding our recent paper, **MineDraft: A Framework for Batch Parallel Speculative Decoding**, which we think fits the scope of this list (speculative decoding / efficient LLM inference).

- **Paper:** https://arxiv.org/abs/2603.18016
- **Project blog:** https://arunv3rma.github.io/blogs/minedraft/minedraft.html
- **Code:** https://github.com/electron-shaders/MineDraft

**TL;DR:** MineDraft accelerates LLM inference by overlapping the *drafting* and *verification* stages of speculative decoding, hiding drafting latency behind verification compute. It maintains two batches of requests so that while one batch is being verified by the target model, the other is being drafted. Experiments on Qwen3, Llama-3.3, and EAGLE models across ShareGPT, LMSYS Arena, and Spec-Bench benchmarks achieve up to **+75% throughput** and **−39% end-to-end latency** over standard speculative decoding. Integrated into vLLM as a production plugin.

**BibTeX:**

```bibtex
@article{minedraft2026,
  title  = {MineDraft: A Framework for Batch Parallel Speculative Decoding},
  author = {Tang, Zhenwei and Verma, Arun and Zhou, Zijian and Wu, Zhaoxuan and Prakash, Alok and Rus, Daniela and Low, Bryan Kian Hsiang},
  journal = {arXiv preprint arXiv:2603.18016},
  year   = {2026},
  url    = {https://arxiv.org/abs/2603.18016}
}
```

Happy to reformat the entry or move it to a different section if you'd prefer — just let me know. Thanks for considering!
